### PR TITLE
unicornFix

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -7,7 +7,7 @@ pid "#{app_path}/tmp/pids/unicorn.pid"
 stderr_path "#{app_path}/log/unicorn.stderr.log"
 stdout_path "#{app_path}/log/unicorn.stdout.log"
 
-listen 3000
+listen "#{rails_root}/tmp/unicorn.sock"
 timeout 60
 
 preload_app true


### PR DESCRIPTION
#what
unicorn.sockの位置を指定

#why
nginxでエラー発生のため